### PR TITLE
Add editdistance to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tb-nightly
 torch>=1.2.0
 torchaudio
 matplotlib
+editdistance


### PR DESCRIPTION
Hi I'm muramasa from Japan.
I got the error when I run
```
python3 main.py --config config/libri/decode_example.yaml --test --njobs 8
```
```
Traceback (most recent call last):
  File "main.py", line 68, in <module>
    from bin.test_asr import Solver
  File "/Users/muratam39/End-to-end-ASR-Pytorch/bin/test_asr.py", line 7, in <module>
    from src.solver import BaseSolver
  File "/Users/muratam39/End-to-end-ASR-Pytorch/src/solver.py", line 10, in <module>
    from src.util import human_format, Timer
  File "/Users/muratam39/End-to-end-ASR-Pytorch/src/util.py", line 7, in <module>
    import editdistance as ed

ModuleNotFoundError: No module named 'editdistance'
```

So, I fixed requirements.txt.(added the library)
Please check and merge this PR.