### PR TITLE
docs: fix misspelling. Abtract -> Abstract

### DIFF
--- a/src/solver.py
+++ b/src/solver.py
@@ -188,7 +188,7 @@ class BaseSolver():
             self.model, self.optimizer.opt = self.amp_lib.initialize(
                 self.model, self.optimizer.opt, opt_level='O1')
 
-    # ----------------------------------- Abtract Methods ------------------------------------------ #
+    # ----------------------------------- Abstract Methods ------------------------------------------ #
     @abc.abstractmethod
     def load_data(self):
         '''


### PR DESCRIPTION
Hi I'm muramasa from Japan.
I found out the misspelling "Abtract" at line 191 of src/solver.py.
I guess it means "Abstract", so I fixed it.

Please check and merge this PR.